### PR TITLE
feat(model): add support for first and last name claims

### DIFF
--- a/jwt/model.go
+++ b/jwt/model.go
@@ -52,6 +52,8 @@ func New(idToken string, signatureAlgorithms []jose.SignatureAlgorithm) (webToke
 	webToken.IssuerAttributes = rawToken.IssuerAttributes
 	webToken.Audiences = rawToken.getAudiences()
 	webToken.Mail = rawToken.getMail()
+	webToken.FirstName = rawToken.getFirstName()
+	webToken.LastName = rawToken.getLastName()
 
 	return
 }

--- a/jwt/model.go
+++ b/jwt/model.go
@@ -37,7 +37,7 @@ type WebToken struct {
 func New(idToken string, signatureAlgorithms []jose.SignatureAlgorithm) (webToken WebToken, err error) {
 	token, parseErr := jwt.ParseSigned(idToken, signatureAlgorithms)
 	if parseErr != nil {
-		err = fmt.Errorf("unable to parse id_token: [%s], %w", idToken, parseErr)
+		err = fmt.Errorf("unable to parse id_token: %w", parseErr)
 		return
 	}
 

--- a/jwt/model_test.go
+++ b/jwt/model_test.go
@@ -11,140 +11,191 @@ import (
 var signatureAlgorithms = []jose.SignatureAlgorithm{jose.HS256}
 var joseTestKey = []byte("0123456789abcdef0123456789abcdef") // 32 bytes
 
-func TestNew(t *testing.T) {
-	issuer := "my-issuer"
-	token := jwt.NewWithClaims(jwt.SigningMethodHS256, &jwt.RegisteredClaims{
-		Issuer: issuer,
-	})
-	tokenString, err := token.SignedString(joseTestKey)
-	assert.NoError(t, err)
-
-	webToken, err := New(tokenString, signatureAlgorithms)
-	assert.NoError(t, err)
-	assert.NotNil(t, webToken)
-	assert.Equal(t, issuer, webToken.Issuer)
-}
-
-func TestNewAndFail(t *testing.T) {
-	tokenString := "just a string"
-	_, err := New(tokenString, signatureAlgorithms)
-	assert.Error(t, err)
-}
-
-func TestNew_DeserializationError(t *testing.T) {
-	// Create a valid JWT header and signature, but with a payload that is not valid JSON
-	// or cannot be unmarshaled into the expected struct.
-	// We'll use jose to construct a token with a payload that is not a JSON object.
-	invalidPayload := "not-a-json-object"
-	signer, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.HS256, Key: joseTestKey}, nil)
-	assert.NoError(t, err)
-
-	object, err := signer.Sign([]byte(invalidPayload))
-	assert.NoError(t, err)
-
-	tokenString, err := object.CompactSerialize()
-	assert.NoError(t, err)
-
-	_, err = New(tokenString, signatureAlgorithms)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "unable to deserialize claims")
-}
-
-func TestNew_WithFirstNameAndLastName(t *testing.T) {
-	claims := map[string]interface{}{
-		"iss":        "test-issuer",
-		"sub":        "test-subject",
-		"first_name": "John",
-		"last_name":  "Doe",
+func TestNew_Success(t *testing.T) {
+	tests := []struct {
+		name       string
+		claims     map[string]interface{}
+		expectedWT WebToken
+	}{
+		{
+			name: "basic issuer claim",
+			claims: map[string]interface{}{
+				"iss": "my-issuer",
+			},
+			expectedWT: WebToken{
+				IssuerAttributes: IssuerAttributes{
+					Issuer: "my-issuer",
+				},
+			},
+		},
+		{
+			name: "with first_name and last_name",
+			claims: map[string]interface{}{
+				"iss":        "test-issuer",
+				"sub":        "test-subject",
+				"first_name": "John",
+				"last_name":  "Doe",
+			},
+			expectedWT: WebToken{
+				IssuerAttributes: IssuerAttributes{
+					Issuer:  "test-issuer",
+					Subject: "test-subject",
+				},
+				UserAttributes: UserAttributes{
+					FirstName: "John",
+					LastName:  "Doe",
+				},
+			},
+		},
+		{
+			name: "with given_name and family_name",
+			claims: map[string]interface{}{
+				"iss":         "test-issuer",
+				"sub":         "test-subject",
+				"given_name":  "Jonathan",
+				"family_name": "Smith",
+			},
+			expectedWT: WebToken{
+				IssuerAttributes: IssuerAttributes{
+					Issuer:  "test-issuer",
+					Subject: "test-subject",
+				},
+				UserAttributes: UserAttributes{
+					FirstName: "Jonathan",
+					LastName:  "Smith",
+				},
+			},
+		},
+		{
+			name: "prefer first_name/last_name over given_name/family_name",
+			claims: map[string]interface{}{
+				"iss":         "test-issuer",
+				"sub":         "test-subject",
+				"first_name":  "John",
+				"last_name":   "Doe",
+				"given_name":  "Jonathan",
+				"family_name": "Smith",
+			},
+			expectedWT: WebToken{
+				IssuerAttributes: IssuerAttributes{
+					Issuer:  "test-issuer",
+					Subject: "test-subject",
+				},
+				UserAttributes: UserAttributes{
+					FirstName: "John",
+					LastName:  "Doe",
+				},
+			},
+		},
+		{
+			name: "fallback to given_name/family_name when first_name/last_name are empty",
+			claims: map[string]interface{}{
+				"iss":         "test-issuer",
+				"sub":         "test-subject",
+				"first_name":  "",
+				"last_name":   "",
+				"given_name":  "Jonathan",
+				"family_name": "Smith",
+			},
+			expectedWT: WebToken{
+				IssuerAttributes: IssuerAttributes{
+					Issuer:  "test-issuer",
+					Subject: "test-subject",
+				},
+				UserAttributes: UserAttributes{
+					FirstName: "Jonathan",
+					LastName:  "Smith",
+				},
+			},
+		},
+		{
+			name: "partial fallback - first_name present, last_name empty",
+			claims: map[string]interface{}{
+				"iss":         "test-issuer",
+				"sub":         "test-subject",
+				"first_name":  "John",
+				"last_name":   "",
+				"given_name":  "Jonathan",
+				"family_name": "Smith",
+			},
+			expectedWT: WebToken{
+				IssuerAttributes: IssuerAttributes{
+					Issuer:  "test-issuer",
+					Subject: "test-subject",
+				},
+				UserAttributes: UserAttributes{
+					FirstName: "John",
+					LastName:  "Smith",
+				},
+			},
+		},
 	}
 
-	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims(claims))
-	tokenString, err := token.SignedString(joseTestKey)
-	assert.NoError(t, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims(tt.claims))
+			tokenString, err := token.SignedString(joseTestKey)
+			assert.NoError(t, err)
 
-	webToken, err := New(tokenString, signatureAlgorithms)
-	assert.NoError(t, err)
-	assert.Equal(t, "John", webToken.FirstName)
-	assert.Equal(t, "Doe", webToken.LastName)
+			webToken, err := New(tokenString, signatureAlgorithms)
+			assert.NoError(t, err)
+			assert.NotNil(t, webToken)
+			assert.Equal(t, tt.expectedWT.Issuer, webToken.Issuer)
+			assert.Equal(t, tt.expectedWT.Subject, webToken.Subject)
+			assert.Equal(t, tt.expectedWT.FirstName, webToken.FirstName)
+			assert.Equal(t, tt.expectedWT.LastName, webToken.LastName)
+		})
+	}
 }
 
-func TestNew_WithGivenNameAndFamilyName(t *testing.T) {
-	claims := map[string]interface{}{
-		"iss":         "test-issuer",
-		"sub":         "test-subject",
-		"given_name":  "Jonathan",
-		"family_name": "Smith",
+func TestNew_Errors(t *testing.T) {
+	tests := []struct {
+		name          string
+		tokenString   string
+		setupToken    func() (string, error)
+		expectedError string
+	}{
+		{
+			name:          "invalid token string",
+			tokenString:   "just a string",
+			expectedError: "unable to parse id_token",
+		},
+		{
+			name: "deserialization error with invalid payload",
+			setupToken: func() (string, error) {
+				// Create a valid JWT header and signature, but with a payload that is not valid JSON
+				invalidPayload := "not-a-json-object"
+				signer, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.HS256, Key: joseTestKey}, nil)
+				if err != nil {
+					return "", err
+				}
+
+				object, err := signer.Sign([]byte(invalidPayload))
+				if err != nil {
+					return "", err
+				}
+
+				return object.CompactSerialize()
+			},
+			expectedError: "unable to deserialize claims",
+		},
 	}
 
-	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims(claims))
-	tokenString, err := token.SignedString(joseTestKey)
-	assert.NoError(t, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var tokenString string
+			var err error
 
-	webToken, err := New(tokenString, signatureAlgorithms)
-	assert.NoError(t, err)
-	assert.Equal(t, "Jonathan", webToken.FirstName)
-	assert.Equal(t, "Smith", webToken.LastName)
-}
+			if tt.setupToken != nil {
+				tokenString, err = tt.setupToken()
+				assert.NoError(t, err)
+			} else {
+				tokenString = tt.tokenString
+			}
 
-func TestNew_PreferFirstLastNameOverGivenFamilyName(t *testing.T) {
-	claims := map[string]interface{}{
-		"iss":         "test-issuer",
-		"sub":         "test-subject",
-		"first_name":  "John",
-		"last_name":   "Doe",
-		"given_name":  "Jonathan",
-		"family_name": "Smith",
+			_, err = New(tokenString, signatureAlgorithms)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tt.expectedError)
+		})
 	}
-
-	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims(claims))
-	tokenString, err := token.SignedString(joseTestKey)
-	assert.NoError(t, err)
-
-	webToken, err := New(tokenString, signatureAlgorithms)
-	assert.NoError(t, err)
-	// Should prefer first_name/last_name over given_name/family_name
-	assert.Equal(t, "John", webToken.FirstName)
-	assert.Equal(t, "Doe", webToken.LastName)
-}
-
-func TestNew_FallbackToGivenFamilyNameWhenFirstLastEmpty(t *testing.T) {
-	claims := map[string]interface{}{
-		"iss":         "test-issuer",
-		"sub":         "test-subject",
-		"first_name":  "",
-		"last_name":   "",
-		"given_name":  "Jonathan",
-		"family_name": "Smith",
-	}
-
-	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims(claims))
-	tokenString, err := token.SignedString(joseTestKey)
-	assert.NoError(t, err)
-
-	webToken, err := New(tokenString, signatureAlgorithms)
-	assert.NoError(t, err)
-	// Should fallback to given_name/family_name when first_name/last_name are empty
-	assert.Equal(t, "Jonathan", webToken.FirstName)
-	assert.Equal(t, "Smith", webToken.LastName)
-}
-
-func TestNew_PartialFallback(t *testing.T) {
-	claims := map[string]interface{}{
-		"iss":         "test-issuer",
-		"sub":         "test-subject",
-		"first_name":  "John",
-		"last_name":   "", // empty
-		"given_name":  "Jonathan",
-		"family_name": "Smith",
-	}
-
-	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims(claims))
-	tokenString, err := token.SignedString(joseTestKey)
-	assert.NoError(t, err)
-
-	webToken, err := New(tokenString, signatureAlgorithms)
-	assert.NoError(t, err)
-	// Should use first_name but fallback to family_name for last name
-	assert.Equal(t, "John", webToken.FirstName)
-	assert.Equal(t, "Smith", webToken.LastName)
 }

--- a/jwt/raw.go
+++ b/jwt/raw.go
@@ -1,9 +1,11 @@
 package jwt
 
 type rawClaims struct {
-	RawAudiences interface{} `json:"aud"` // RawAudiences could be a []string or string depending on the serialization in IdP site
-	RawEmail     string      `json:"email,omitempty"`
-	RawMail      string      `json:"mail,omitempty"`
+	RawAudiences  interface{} `json:"aud"` // RawAudiences could be a []string or string depending on the serialization in IdP site
+	RawEmail      string      `json:"email,omitempty"`
+	RawMail       string      `json:"mail,omitempty"`
+	RawGivenName  string      `json:"given_name,omitempty"`
+	RawFamilyName string      `json:"family_name,omitempty"`
 }
 
 type rawWebToken struct {
@@ -16,6 +18,22 @@ func (r rawWebToken) getMail() (mail string) {
 	mail = r.RawMail
 	if mail == "" {
 		mail = r.RawEmail
+	}
+	return
+}
+
+func (r rawWebToken) getLastName() (lastName string) {
+	lastName = r.LastName
+	if lastName == "" {
+		lastName = r.RawFamilyName
+	}
+	return
+}
+
+func (r rawWebToken) getFirstName() (firstName string) {
+	firstName = r.FirstName
+	if firstName == "" {
+		firstName = r.RawGivenName
 	}
 	return
 }

--- a/jwt/raw.go
+++ b/jwt/raw.go
@@ -1,5 +1,7 @@
 package jwt
 
+import "strings"
+
 type rawClaims struct {
 	RawAudiences  interface{} `json:"aud"` // RawAudiences could be a []string or string depending on the serialization in IdP site
 	RawEmail      string      `json:"email,omitempty"`
@@ -15,7 +17,7 @@ type rawWebToken struct {
 }
 
 func (r rawWebToken) getMail() (mail string) {
-	mail = r.RawMail
+	mail = strings.TrimSpace(r.RawMail)
 	if mail == "" {
 		mail = r.RawEmail
 	}
@@ -23,7 +25,7 @@ func (r rawWebToken) getMail() (mail string) {
 }
 
 func (r rawWebToken) getLastName() (lastName string) {
-	lastName = r.LastName
+	lastName = strings.TrimSpace(r.LastName)
 	if lastName == "" {
 		lastName = r.RawFamilyName
 	}
@@ -31,7 +33,7 @@ func (r rawWebToken) getLastName() (lastName string) {
 }
 
 func (r rawWebToken) getFirstName() (firstName string) {
-	firstName = r.FirstName
+	firstName = strings.TrimSpace(r.FirstName)
 	if firstName == "" {
 		firstName = r.RawGivenName
 	}

--- a/jwt/raw.go
+++ b/jwt/raw.go
@@ -19,7 +19,7 @@ type rawWebToken struct {
 func (r rawWebToken) getMail() (mail string) {
 	mail = strings.TrimSpace(r.RawMail)
 	if mail == "" {
-		mail = r.RawEmail
+		mail = strings.TrimSpace(r.RawEmail)
 	}
 	return
 }
@@ -27,7 +27,7 @@ func (r rawWebToken) getMail() (mail string) {
 func (r rawWebToken) getLastName() (lastName string) {
 	lastName = strings.TrimSpace(r.LastName)
 	if lastName == "" {
-		lastName = r.RawFamilyName
+		lastName = strings.TrimSpace(r.RawFamilyName)
 	}
 	return
 }
@@ -35,7 +35,7 @@ func (r rawWebToken) getLastName() (lastName string) {
 func (r rawWebToken) getFirstName() (firstName string) {
 	firstName = strings.TrimSpace(r.FirstName)
 	if firstName == "" {
-		firstName = r.RawGivenName
+		firstName = strings.TrimSpace(r.RawGivenName)
 	}
 	return
 }

--- a/jwt/raw_test.go
+++ b/jwt/raw_test.go
@@ -37,3 +37,93 @@ func TestParseAudiencesString(t *testing.T) {
 	assert.Contains(t, parsedAudiences, "audience1")
 	assert.Equal(t, len(parsedAudiences), 1)
 }
+
+func TestGetFirstName_PreferFirstName(t *testing.T) {
+	token := rawWebToken{
+		UserAttributes: UserAttributes{
+			FirstName: "John",
+		},
+		rawClaims: rawClaims{
+			RawGivenName: "Jonathan",
+		},
+	}
+
+	firstName := token.getFirstName()
+
+	assert.Equal(t, "John", firstName)
+}
+
+func TestGetFirstName_FallbackToRawGivenName(t *testing.T) {
+	token := rawWebToken{
+		UserAttributes: UserAttributes{
+			FirstName: "",
+		},
+		rawClaims: rawClaims{
+			RawGivenName: "Jonathan",
+		},
+	}
+
+	firstName := token.getFirstName()
+
+	assert.Equal(t, "Jonathan", firstName)
+}
+
+func TestGetFirstName_BothEmpty(t *testing.T) {
+	token := rawWebToken{
+		UserAttributes: UserAttributes{
+			FirstName: "",
+		},
+		rawClaims: rawClaims{
+			RawGivenName: "",
+		},
+	}
+
+	firstName := token.getFirstName()
+
+	assert.Equal(t, "", firstName)
+}
+
+func TestGetLastName_PreferLastName(t *testing.T) {
+	token := rawWebToken{
+		UserAttributes: UserAttributes{
+			LastName: "Doe",
+		},
+		rawClaims: rawClaims{
+			RawFamilyName: "Smith",
+		},
+	}
+
+	lastName := token.getLastName()
+
+	assert.Equal(t, "Doe", lastName)
+}
+
+func TestGetLastName_FallbackToRawFamilyName(t *testing.T) {
+	token := rawWebToken{
+		UserAttributes: UserAttributes{
+			LastName: "",
+		},
+		rawClaims: rawClaims{
+			RawFamilyName: "Smith",
+		},
+	}
+
+	lastName := token.getLastName()
+
+	assert.Equal(t, "Smith", lastName)
+}
+
+func TestGetLastName_BothEmpty(t *testing.T) {
+	token := rawWebToken{
+		UserAttributes: UserAttributes{
+			LastName: "",
+		},
+		rawClaims: rawClaims{
+			RawFamilyName: "",
+		},
+	}
+
+	lastName := token.getLastName()
+
+	assert.Equal(t, "", lastName)
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Improved extraction of user first and last names from authentication tokens, supporting multiple claim variants (first/last and given/family) with prioritized fallbacks and whitespace handling for more reliable name population.
  - More robust handling of email claim whitespace to ensure consistent mail extraction.

- Tests
  - Added comprehensive unit tests validating name-mapping priority/fallbacks and related claim handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->