### PR TITLE
chore: slice defaulting

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -167,10 +167,14 @@ func traverseStruct(value reflect.Value, flagSet *pflag.FlagSet, prefix string) 
 			}
 			flagSet.Bool(prefix+tag, defaultBoolValue, description)
 		case reflect.Slice:
+			var defaultSliceValue []string
+			if defaultStrValue != "" {
+				defaultSliceValue = strings.Split(defaultStrValue, ",")
+			}
 			if fieldValue.Type().Elem().Kind() != reflect.String {
 				return fmt.Errorf("unsupported slice element type %s for field %s", fieldValue.Type().Elem().Kind(), field.Name)
 			}
-			flagSet.StringSlice(prefix+tag, []string{}, description)
+			flagSet.StringSlice(prefix+tag, defaultSliceValue, description)
 		default:
 			return fmt.Errorf("unsupported field type %s for field %s", fieldValue.Kind(), field.Name)
 		}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -36,7 +36,7 @@ func TestBindConfigToFlags(t *testing.T) {
 		CustomFlagStruct2 struct {
 			CustomFlagDuration time.Duration `mapstructure:"custom-flag-duration-2"`
 		} `mapstructure:"le-strFlag"`
-		Slice []string `mapstructure:"slice" description:"This is a slice of strings"`
+		Slice []string `mapstructure:"slice" description:"This is a slice of strings" default:"one,two,three"`
 	}
 
 	testStruct := test{}
@@ -75,6 +75,10 @@ func TestBindConfigToFlags(t *testing.T) {
 	assert.NotNil(t, durationFlag)
 	assert.Equal(t, "This is a custom flag with duration value", durationFlag.Usage)
 	assert.Equal(t, "1m0s", durationFlag.DefValue)
+
+	sliceFlag := cmd.Flags().Lookup("slice")
+	assert.NotNil(t, sliceFlag)
+	assert.Equal(t, "[one,two,three]", sliceFlag.DefValue)
 }
 
 func TestBindConfigToFlagsWrongTypeInt(t *testing.T) {

--- a/context/context.go
+++ b/context/context.go
@@ -18,8 +18,12 @@ const DefaultShutdownTimeout = 3 * time.Second
 type ShutdownTimeoutKey struct{}
 
 // Creates a new context and returns context, cancel and shutdown function. It should be directly followed by a defer call to shutdown.
-func StartContext(log *logger.Logger, cfg any, timeout time.Duration) (ctx context.Context, cancel context.CancelCauseFunc, shutdown func()) {
-	parentCtx := context.WithValue(context.Background(), ShutdownTimeoutKey{}, timeout)
+func StartContext(log *logger.Logger, cfg any, timeout time.Duration) (context.Context, context.CancelCauseFunc, func()) {
+	return StartWithContext(context.Background(), log, cfg, timeout)
+}
+
+func StartWithContext(ctx context.Context, log *logger.Logger, cfg any, timeout time.Duration) (context.Context, context.CancelCauseFunc, func()) {
+	parentCtx := context.WithValue(ctx, ShutdownTimeoutKey{}, timeout)
 	ctxWithCause, cancel := context.WithCancelCause(parentCtx)
 	ctx, c := NotifyShutdownContext(ctxWithCause)
 	ctx = logger.SetLoggerInContext(ctx, log)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration fields now support default values for comma-separated string lists
  * Added new context initialization method that accepts a custom base context

* **Tests**
  * Updated test coverage to validate default slice field values

<!-- end of auto-generated comment: release notes by coderabbit.ai -->