### PR TITLE
Add function wrapper to recover from panics and send them to Sentry

### DIFF
--- a/sentry/sentry_test.go
+++ b/sentry/sentry_test.go
@@ -33,3 +33,27 @@ func TestCaptureSentryError(t *testing.T) {
 		CaptureSentryError(err, nil)
 	})
 }
+
+func TestWrap_NoPanic(t *testing.T) {
+	called := false
+
+	wrapped := Wrap(func() {
+		called = true
+	}, nil)
+
+	assert.NotPanics(t, func() {
+		wrapped()
+	})
+
+	assert.True(t, called, "wrapped function should be executed")
+}
+
+func TestWrap_PanicIsRecovered(t *testing.T) {
+	wrapped := Wrap(func() {
+		panic("nil pointer exception")
+	}, Tags{"component": "test"})
+
+	assert.NotPanics(t, func() {
+		wrapped()
+	})
+}


### PR DESCRIPTION
This PR adds a convenient wrapper `sentry.Wrap` for function calls that recovers from panics that might occur inside the function and sends them to Sentry with a tag "panic" added. It's also possible to provide additional tags and extras.
There is also a `sentry.Go` wrapper that does the same for asynchronous usage. 

On-behalf-of: SAP peter.teich@sap.com