### PR TITLE
fix: add a check if the instance has a deletion timestamp and no finalizers before updating status

### DIFF
--- a/controller/lifecycle/lifecycle.go
+++ b/controller/lifecycle/lifecycle.go
@@ -147,9 +147,14 @@ func Reconcile(ctx context.Context, nName types.NamespacedName, instance runtime
 	}
 
 	if !l.Config().ReadOnly {
-		err = updateStatus(ctx, cl, originalCopy, instance, log, generationChanged, sentryTags)
-		if err != nil {
-			return result, err
+		// Skip status update if all finalizers are removed (object will be deleted)
+		if instance.GetDeletionTimestamp() != nil && len(instance.GetFinalizers()) == 0 {
+			log.Info().Msg("skipping status update - all finalizers removed, object will be deleted")
+		} else {
+			err = updateStatus(ctx, cl, originalCopy, instance, log, generationChanged, sentryTags)
+			if err != nil {
+				return result, err
+			}
 		}
 	}
 


### PR DESCRIPTION
 add a check if the instance has a deletion timestamp and no finalizers then dont update the status because the object will be deleted or is already deleted
 
 Explanation of the issue:
 we execute the subroutines 1 by 1
 When the last finalizer is removed, the CR will be deleted.

  we still try to go to

  if !l.Config().ReadOnly {
    err = updateStatus(ctx, cl, originalCopy, instance, log, generationChanged, sentryTags)
    if err != nil {
      return result, err
    }
  }

  which tries to update a resource that is already deleted, hence we have StorageError: invalid object, Code: 4
  -> (explanation for the error) The storageError: invalid object, Code: 4 in Kubernetes generally indicates a conflict or race condition where an operation (update/delete) is attempted on an object in etcd that has already been deleted, changed, or has a mismatched ResourceVersion/UID. It is a "Precondition failed" error, often occurring during rapid, concurrent updates or deletion