### PR TITLE
fix: avoid panic by not reusing zerolog Trace event

### DIFF
--- a/policy_services/common.go
+++ b/policy_services/common.go
@@ -22,7 +22,9 @@ func createClient(ctx context.Context, iamApiUrl string) *graphql.Client {
 	client := graphql.NewClient(iamApiUrl, graphql.WithHTTPClient(hc))
 
 	if log != nil {
-		client.Log = log.ComponentLogger("graphql").Trace().Msg
+		client.Log = func(msg string) {
+			log.ComponentLogger("graphql").Trace().Msg(msg)
+		}
 	}
 	return client
 }


### PR DESCRIPTION
fix for https://github.com/platform-mesh/golang-commons/issues/223